### PR TITLE
Simplify display and end the game

### DIFF
--- a/whereiswaldo.pde
+++ b/whereiswaldo.pde
@@ -1,6 +1,5 @@
 PImage img;
 
-
 void setup() {
   size(700, 431);
   frameRate(30);
@@ -10,7 +9,7 @@ void setup() {
   // Only need to load the pixels[] array once, because we're only
   // manipulating pixels[] inside draw(), not drawing shapes.
   loadPixels();
-  
+  colorMode(HSB, 100);
 }
 
 boolean gameOver = false;
@@ -28,6 +27,7 @@ void mouseClicked() {
 }
 
 void draw() {
+  noCursor();
   //imageMode(CORNER);
   //image(img, 50, 50);
   if (gameOver == true) {
@@ -40,7 +40,6 @@ void draw() {
   else {
     playGame();
   }
-
 }
 
 void playGame() {
@@ -48,25 +47,22 @@ void playGame() {
     for (int y = 0; y < img.height; y++ ) {
       // Calculate the 1D location from a 2D grid
       int loc = x + y*img.width;
-      // Get the R,G,B values from image
-      float r,g,b;
-      r = red (img.pixels[loc]);
-      g = green (img.pixels[loc]);
-      b = blue (img.pixels[loc]);
+      // Get the H,S,B values from image
+      float h, s , b;
+      h = hue (img.pixels[loc]);
+      s = saturation (img.pixels[loc]);
+      b = brightness (img.pixels[loc]);
       // Calculate an amount to change brightness based on proximity to the mouse
       float maxdist = 100;//dist(0,0,width,height);
       float d = dist(x, y, mouseX, mouseY);
-      float adjustbrightness = 255*(maxdist-d)/maxdist;
-      r += adjustbrightness;
-      g += adjustbrightness;
-      b += adjustbrightness;
-      // Constrain RGB to make sure they are within 0-255 color range
-      r = constrain(r, 0, 255);
-      g = constrain(g, 0, 255);
-      b = constrain(b, 0, 255);
+      //float adjustbrightness = (maxdist-d)/maxdist;
+      if (d > maxdist) {
+        b = 0;
+      } 
+      // Constrain HSB to make sure they are within 0-100 brightness range
+      b = constrain(b, 0, 100);
       // Make a new color and set pixel in the window
-      //color c = color(r, g, b);
-      color c = color(r,g,b);
+      color c = color(h,s,b);
       pixels[y*width + x] = c;
     }
   }

--- a/whereiswaldo.pde
+++ b/whereiswaldo.pde
@@ -28,13 +28,8 @@ void mouseClicked() {
 
 void draw() {
   noCursor();
-  //imageMode(CORNER);
-  //image(img, 50, 50);
   if (gameOver == true) {
-    loadPixels();
-    img = loadImage ("waldo.jpg");
-    img.loadPixels();
-    updatePixels();
+    image(img, 0, 0);
     noLoop ();
   }
   else {


### PR DESCRIPTION
- make the unhidden image area ('flashlight' turned on by the user's mouse) more visible
- simplify masking treatment using HSB colour mode instead of RGB mode
- show full picture when user wins